### PR TITLE
feat: a better way to embed widget instances in a template 

### DIFF
--- a/examples/EmbeddingJupyterWidgetsInVueTemplate.ipynb
+++ b/examples/EmbeddingJupyterWidgetsInVueTemplate.ipynb
@@ -1,0 +1,93 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipyvue as vue\n",
+    "import ipywidgets as widgets\n",
+    "from traitlets import (Unicode, List, Int, Bool, Any, Dict)\n",
+    "\n",
+    "slider1 = widgets.IntSlider(description='Slider 1', value=20)\n",
+    "slider2 = widgets.IntSlider(description='Slider 2', value=40)\n",
+    "\n",
+    "class MyComponent(vue.VueTemplate):\n",
+    "    \n",
+    "    items = List([{\n",
+    "        'title': 'Title 1',\n",
+    "        'content': slider1\n",
+    "    }, {\n",
+    "        'title': 'Title 2',\n",
+    "        'content': slider2\n",
+    "    }]).tag(sync=True, **widgets.widget_serialization)\n",
+    "    \n",
+    "    single_widget = Any(\n",
+    "        widgets.IntSlider(description='Single slider', value=40)\n",
+    "    ).tag(sync=True, **widgets.widget_serialization)\n",
+    "\n",
+    "\n",
+    "    template=Unicode(\"\"\"\n",
+    "        <div>\n",
+    "            <div v-for=\"item in items\" :key=\"item.title + item.content\">\n",
+    "                {{ item.title }}: <jupyter-widget :widget=\"item.content\" />\n",
+    "            </div>\n",
+    "            Single widget: <jupyter-widget :widget=\"single_widget\" />\n",
+    "        </div>\n",
+    "    \"\"\").tag(sync=True)\n",
+    "\n",
+    "my_component = MyComponent()\n",
+    "my_component"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add a widget\n",
+    "slider3 = widgets.IntSlider(description='Slider 3', value=60)\n",
+    "my_component.items=[*my_component.items, {'title': 'Title 3', 'content': slider3}]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_component.single_widget = widgets.IntSlider(description='changed')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/js/src/VueTemplateRenderer.js
+++ b/js/src/VueTemplateRenderer.js
@@ -50,6 +50,7 @@ function createComponentObject(model, parentView) {
         components: {
             ...createInstanceComponents(instanceComponents, parentView),
             ...createClassComponents(classComponents, model, parentView),
+            ...createWidgetComponent(model, parentView),
         },
         computed: aliasRefProps(model),
         template: trimTemplateTags(model.get('template')),
@@ -190,4 +191,40 @@ function aliasRefProps(model) {
                 return this[propRef];
             },
         }), {});
+}
+
+function createWidgetComponent(model, parentView) {
+    return {
+        'jupyter-widget': {
+            props: ['widget'],
+            data() {
+                return {
+                    component: null,
+                };
+            },
+            created() {
+                this.update();
+            },
+            watch: {
+                widget() {
+                    this.update();
+                },
+            },
+            methods: {
+                update() {
+                    model.widget_manager
+                        .get_model(this.widget.substring(10))
+                        .then((mdl) => {
+                            this.component = createComponentObject(mdl, parentView);
+                        });
+                },
+            },
+            render(createElement) {
+                if (!this.component) {
+                    return createElement('div');
+                }
+                return createElement(this.component);
+            },
+        },
+    };
 }

--- a/js/src/VueView.js
+++ b/js/src/VueView.js
@@ -10,13 +10,14 @@ export class VueView extends DOMWidgetView {
 
     render() {
         super.render();
+        this.displayed.then(() => {
+            const vueEl = document.createElement('div');
+            this.el.appendChild(vueEl);
 
-        const vueEl = document.createElement('div');
-        this.el.appendChild(vueEl);
-
-        this.vueApp = new Vue({
-            el: vueEl,
-            render: createElement => vueRender(createElement, this.model, this, {}),
+            this.vueApp = new Vue({
+                el: vueEl,
+                render: createElement => vueRender(createElement, this.model, this, {}),
+            });
         });
     }
 }


### PR DESCRIPTION
```python
import ipyvue as vue
import ipywidgets as widgets
from traitlets import (Unicode, List, Int, Bool, Any, Dict)

slider1 = widgets.IntSlider(description='Slider 1', value=20)
slider2 = widgets.IntSlider(description='Slider 2', value=40)

class MyComponent(vue.VueTemplate):
    
    items = List([{
        'title': 'Title 1',
        'content': slider1
    }, {
        'title': 'Title 2',
        'content': slider2
    }]).tag(sync=True, **widgets.widget_serialization)
    
    single_widget = Any(
        widgets.IntSlider(description='Single slider', value=40)
    ).tag(sync=True, **widgets.widget_serialization)


    template=Unicode("""
        <div>
            <div v-for="item in items" :key="item.title + item.content">
                {{ item.title }}: <jupyter-widget :widget="item.content" />
            </div>
            Single widget: <jupyter-widget :widget="single_widget" />
        </div>
    """).tag(sync=True)

my_component = MyComponent()
my_component
```