### PR TITLE
feat: allow @jupyter-widgets/base for jupyter lab 2.0 compatibility

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -50,7 +50,7 @@
     "webpack-cli": "^3.3.2"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^1.0.0 || ^2.0.0",
+    "@jupyter-widgets/base": "^1.0.0 || ^2.0.0 || ^3.0.0",
     "@mariobuikhuizen/vue-compiler-addon": "2.6.10",
     "core-js": "^3.0.1",
     "lodash": "^4.17.11",


### PR DESCRIPTION
cc @jasongrout 

Following https://github.com/jupyter-widgets/ipywidgets/pull/2781

However, I did not get this to work, using:
```bash
conda create -n lab2test -c conda-forge nodejs ipywidgets -y
conda activate lab2test
conda install -c conda-forge --only-deps  jupyterlab -y  
pip install jupyterlab==2.0.0rc0
pip install -e ~/src/ipyvue
jupyter labextension install @jupyter-widgets/jupyterlab-manager@next ~/src/ipyvue/js    
jupyter lab
```


Code cell to test:
```python
import ipyvue
class Test(ipyvue.VueTemplate):
    pass
Test(template="<h1/>")
```



![image](https://user-images.githubusercontent.com/1765949/74667942-85d47080-51a4-11ea-9d52-38dbdcf1ec84.png)

