### PR TITLE
feat: read JavaScript and CSS from template string

### DIFF
--- a/examples/DeepWatch.ipynb
+++ b/examples/DeepWatch.ipynb
@@ -1,0 +1,83 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipyvuetify as v\n",
+    "import traitlets\n",
+    "class MyDeep(v.VuetifyTemplate):\n",
+    "    deep = traitlets.Dict({'prop': 1,\n",
+    "                          'deeper': {'prop': 2}}).tag(sync=True)\n",
+    "    not_deep = traitlets.Unicode('x').tag(sync=True)\n",
+    "    deep_array = traitlets.List(['array']).tag(sync=True)\n",
+    "    deep_array2 = traitlets.List([{'prop': 'array2'}]).tag(sync=True)\n",
+    "    template = traitlets.Unicode('''\n",
+    "        <div>\n",
+    "            <v-text-field v-model=\"deep.prop\" />\n",
+    "            <v-text-field v-model=\"deep.deeper.prop\" />\n",
+    "            <v-text-field v-model=\"not_deep\" />\n",
+    "            <v-text-field v-model=\"deep_array[0]\" />\n",
+    "            <v-text-field v-model=\"deep_array2[0].prop\" />\n",
+    "            {{ deep.prop }} |\n",
+    "            {{ deep.deeper.prop }} |\n",
+    "            {{ not_deep }} |\n",
+    "            {{ deep_array[0] }} |\n",
+    "            {{ deep_array2[0].prop }}\n",
+    "        </div>\n",
+    "    ''').tag(sync=True)\n",
+    "    \n",
+    "md = MyDeep()\n",
+    "md"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[md.deep, md.not_deep, md.deep_array, md.deep_array2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "md.deep['deeper']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/js/src/VueTemplateRenderer.js
+++ b/js/src/VueTemplateRenderer.js
@@ -57,12 +57,22 @@ function createComponentObject(model, parentView) {
     const instanceComponents = componentEntries.filter(([, v]) => v instanceof WidgetModel);
     const classComponents = componentEntries.filter(([, v]) => !(v instanceof WidgetModel));
 
+    function callVueFn(name, this_) {
+        if (vuefile.SCRIPT && vuefile.SCRIPT[name]) {
+            vuefile.SCRIPT[name].bind(this_)();
+        }
+    }
+
     return {
         data() {
             return { ...data, ...createDataMapping(model) };
         },
+        beforeCreate() {
+            callVueFn('beforeCreate', this);
+        },
         created() {
             addModelListeners(model, this);
+            callVueFn('created', this);
         },
         watch: { ...vuefile.SCRIPT && vuefile.SCRIPT.watch, ...createWatches(model, parentView) },
         methods: {
@@ -77,6 +87,24 @@ function createComponentObject(model, parentView) {
         },
         computed: { ...vuefile.SCRIPT && vuefile.SCRIPT.computed, ...aliasRefProps(model) },
         template: vuefile.TEMPLATE || model.get('template'),
+        beforeMount() {
+            callVueFn('beforeMount', this);
+        },
+        mounted() {
+            callVueFn('mounted', this);
+        },
+        beforeUpdate() {
+            callVueFn('beforeUpdate', this);
+        },
+        updated() {
+            callVueFn('updated', this);
+        },
+        beforeDestroy() {
+            callVueFn('beforeDestroy', this);
+        },
+        destroyed() {
+            callVueFn('destroyed', this);
+        },
     };
 }
 


### PR DESCRIPTION
.vue files like this are now possible (instead of using the methods and css traitlets): 

```HTML
<template>
    <span></span>
</template>

<script>
    module.exports = {
        methods: {
            myMethod() {
            }
        },
        computed: {
            test() {
            }
        },
        watch: {
            prop(value) {
            }
        }
    }
</script>

<style id="my-component-id">

</style>
```
In addition to `methods`, `computed` and `watch` are now also available.

The `id` attribute in the style tag is used to prevent each instance from adding a style tag to the header of the page. 
