### PR TITLE
fix: JupyterPhosphorWidget was renamed to JupyterLuminoWidget

### DIFF
--- a/js/src/VueRenderer.js
+++ b/js/src/VueRenderer.js
@@ -1,9 +1,12 @@
 /* eslint camelcase: ['error', {allow: ['v_model']}] */
-import { JupyterPhosphorWidget } from '@jupyter-widgets/base';
+import * as base from '@jupyter-widgets/base';
 import { vueTemplateRender } from './VueTemplateRenderer'; // eslint-disable-line import/no-cycle
 import { VueModel } from './VueModel';
 import { VueTemplateModel } from './VueTemplateModel';
+
 import Vue from './VueWithCompiler';
+
+const JupyterPhosphorWidget = base.JupyterPhosphorWidget || base.JupyterLuminoWidget;
 
 export function createObjectForNestedModel(model, parentView) {
     return {


### PR DESCRIPTION
This issue occured installing ipywidgets 8 (master) and using ipyvue
from the classical notebook. For some reason I do not get the same issue
in lab.